### PR TITLE
Fix unit tests path and mocks

### DIFF
--- a/tests/Tests.Unit/AuthServiceTests.cs
+++ b/tests/Tests.Unit/AuthServiceTests.cs
@@ -1,6 +1,9 @@
-﻿using Moq;
+using Moq;
 using OnigiriShop.Data;
 using OnigiriShop.Services;
+using OnigiriShop.Data.Interfaces;
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.JSInterop;
 using System.Security.Claims;
 
 namespace Tests.Unit
@@ -10,9 +13,16 @@ namespace Tests.Unit
         private static AuthService BuildService(ClaimsPrincipal user)
         {
             var mockProvider = new Mock<SessionAuthenticationStateProvider>(null);
-            var cartProvider = new Mock<CartProvider>();
             mockProvider.Setup(x => x.GetAuthenticationStateAsync())
                 .ReturnsAsync(new Microsoft.AspNetCore.Components.Authorization.AuthenticationState(user));
+
+            var cartService = new Mock<CartService>(MockBehavior.Loose, (ISqliteConnectionFactory)null);
+            var anonCart = new Mock<AnonymousCartService>(MockBehavior.Loose, (IJSRuntime)null);
+            var prodService = new Mock<ProductService>(MockBehavior.Loose, (ISqliteConnectionFactory)null);
+            var authProvider = new Mock<AuthenticationStateProvider>();
+
+            var cartProvider = new Mock<CartProvider>(cartService.Object, anonCart.Object, prodService.Object, authProvider.Object);
+
             return new AuthService(mockProvider.Object, cartProvider.Object);
         }
 
@@ -101,7 +111,11 @@ namespace Tests.Unit
                 .ReturnsAsync(new Microsoft.AspNetCore.Components.Authorization.AuthenticationState(
                     new ClaimsPrincipal(new ClaimsIdentity())));
             mockProvider.Setup(x => x.SignOutAsync()).Returns(Task.CompletedTask).Verifiable();
-            var cartProvider = new Mock<CartProvider>();
+            var cartService = new Mock<CartService>(MockBehavior.Loose, (ISqliteConnectionFactory)null);
+            var anonCart = new Mock<AnonymousCartService>(MockBehavior.Loose, (IJSRuntime)null);
+            var prodService = new Mock<ProductService>(MockBehavior.Loose, (ISqliteConnectionFactory)null);
+            var authProvider = new Mock<AuthenticationStateProvider>();
+            var cartProvider = new Mock<CartProvider>(cartService.Object, anonCart.Object, prodService.Object, authProvider.Object);
 
             var service = new AuthService(mockProvider.Object, cartProvider.Object);
 

--- a/tests/Tests.Unit/FakeSqliteConnectionFactory.cs
+++ b/tests/Tests.Unit/FakeSqliteConnectionFactory.cs
@@ -4,8 +4,25 @@ using System.Data;
 
 namespace Tests.Unit
 {
+    // Wraps an existing connection but ignores Dispose so that unit tests can
+    // pass the same in-memory connection without it being closed by the service
+    internal class NonDisposableConnection(SqliteConnection inner) : IDbConnection
+    {
+        public string ConnectionString { get => inner.ConnectionString; set => inner.ConnectionString = value; }
+        public int ConnectionTimeout => inner.DefaultTimeout;
+        public string Database => inner.Database;
+        public ConnectionState State => inner.State;
+        public IDbTransaction BeginTransaction() => inner.BeginTransaction();
+        public IDbTransaction BeginTransaction(IsolationLevel il) => inner.BeginTransaction(il);
+        public void ChangeDatabase(string databaseName) => inner.ChangeDatabase(databaseName);
+        public void Close() => inner.Close();
+        public IDbCommand CreateCommand() => inner.CreateCommand();
+        public void Open() => inner.Open();
+        public void Dispose() { /* no-op */ }
+    }
+
     public class FakeSqliteConnectionFactory(SqliteConnection conn) : ISqliteConnectionFactory
     {
-        public IDbConnection CreateConnection() => conn;
+        public IDbConnection CreateConnection() => new NonDisposableConnection(conn);
     }
 }

--- a/tests/Tests.Unit/InMemorySqliteDbHelper.cs
+++ b/tests/Tests.Unit/InMemorySqliteDbHelper.cs
@@ -9,8 +9,8 @@ namespace Tests.Unit
         private static string GetSchemaPath()
         {
             var baseDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            // Adapter la remontée (..), selon la profondeur réelle du dossier "bin/Debug/net8.0"
-            var schemaPath = Path.GetFullPath(Path.Combine(baseDir, @"..\..\..\..\..\src\OnigiriShop\SQL\init_db.sql"));
+            // Construction robuste du chemin quel que soit l'OS
+            var schemaPath = Path.GetFullPath(Path.Combine(baseDir!, "..", "..", "..", "..", "..", "src", "OnigiriShop", "SQL", "init_db.sql"));
             return schemaPath;
         }
         /// <summary>
@@ -23,7 +23,8 @@ namespace Tests.Unit
             if (!File.Exists(schemaPath))
                 throw new FileNotFoundException($"Fichier de schéma SQL non trouvé : {schemaPath}");
 
-            using var conn = new SqliteConnection("Data Source=:memory:");
+            // Ne pas utiliser 'using' pour conserver la connexion ouverte
+            var conn = new SqliteConnection("Data Source=:memory:");
             await conn.OpenAsync();
 
             var schemaSql = await File.ReadAllTextAsync(schemaPath);


### PR DESCRIPTION
## Summary
- keep in-memory SQLite connection open for tests
- prevent test factory from disposing connection
- mock `CartProvider` dependencies so AuthService unit tests run

## Testing
- `dotnet test tests/Tests.Unit/Tests.Unit.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_687cc8c29bac832895abb0c33ab29595