### PR TITLE
Fix seed: ajout de livraisons manquantes

### DIFF
--- a/src/OnigiriShop/SQL/seed.sql
+++ b/src/OnigiriShop/SQL/seed.sql
@@ -24,6 +24,11 @@ VALUES
 ('Créteil Echat', '2025-05-20 14:00:00', 0, NULL, NULL, NULL, '', 0, CURRENT_TIMESTAMP),
 ('République', '2025-06-10 13:00:00', 0, NULL, NULL, NULL, '', 0, CURRENT_TIMESTAMP),
 ('Créteil Echat', '2025-06-20 14:00:00', 0, NULL, NULL, NULL, '', 0, CURRENT_TIMESTAMP);
+INSERT INTO Delivery
+(Place, DeliveryAt, IsRecurring, RecurrenceFrequency, RecurrenceInterval, RecurrenceRule, Comment, IsDeleted, CreatedAt)
+VALUES
+('République', '2025-06-01 13:00:00', 0, NULL, NULL, NULL, '', 0, CURRENT_TIMESTAMP),
+('République', '2025-06-11 13:00:00', 0, NULL, NULL, NULL, '', 0, CURRENT_TIMESTAMP);
 -- Ici : IsRecurring=1, RecurrenceFrequency=2 (semaine), RecurrenceInterval=1
 
 -- Utilisateur admin (Arnaud Wissart)


### PR DESCRIPTION
## Résumé
- ajout de deux entrées `Delivery` pour couvrir les ID manquants dans le seed

## Testing
- `dotnet test --no-build` *(échec: dotnet absent)*

------
https://chatgpt.com/codex/tasks/task_e_6889bc3aa430832888bb6faf40d9b383