### PR TITLE
docs: documenter l'absence du module inventory-web

### DIFF
--- a/docs/inventory-wizard-status.md
+++ b/docs/inventory-wizard-status.md
@@ -1,0 +1,7 @@
+# Inventaire : état du dépôt
+
+Les tâches demandées concernent le wizard d'inventaire sous `src/inventory-web/src/app/pages/inventory`, mais ce dépôt ne contient pas ce module.
+
+Après inspection de l'arborescence (`find . -maxdepth 5 -type d -name "*inventory*"`), aucun dossier ni fichier relatif à `inventory-web` ou au wizard n'est présent. En conséquence, il est impossible d'appliquer les modifications (suppression de l'étape utilisateur, mise à jour du stepper, etc.) dans l'état actuel du dépôt.
+
+Merci de fournir la branche ou le module adéquat afin de poursuivre les changements.


### PR DESCRIPTION
## Summary
- add documentation explaining that the inventory-web module is missing from the repository
- note that the requested wizard updates cannot be applied without the module

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e3599ba784832883eea151bf5f7a14